### PR TITLE
Change Pointer CBOR representation to a kinded union (breaking change)

### DIFF
--- a/hamt.go
+++ b/hamt.go
@@ -59,9 +59,6 @@ var ErrMalformedHamt = fmt.Errorf("HAMT node was malformed")
 // array. Indexes `[1]` and `[2]` are not present, but index `[3]` is at
 // the second position of our Pointers array.
 //
-// (Note: the `refmt` tags are ignored by cbor-gen which will generate an
-// array type rather than map.)
-//
 // The IPLD Schema representation of this data structure is as follows:
 //
 // 		type Node struct {
@@ -69,8 +66,8 @@ var ErrMalformedHamt = fmt.Errorf("HAMT node was malformed")
 // 			pointers [Pointer]
 // 		} representation tuple
 type Node struct {
-	Bitfield *big.Int   `refmt:"bf"`
-	Pointers []*Pointer `refmt:"p"`
+	Bitfield *big.Int
+	Pointers []*Pointer
 
 	bitWidth int
 	hash     func([]byte) []byte
@@ -81,10 +78,11 @@ type Node struct {
 
 // Pointer is an element in a HAMT node's Pointers array, encoded as an IPLD
 // tuple in DAG-CBOR of shape:
-//   {"0": CID} or {"1": [KV...]}
-// Where a map with a single key of "0" contains a Link, where a map with a
-// single key of "1" contains a KV bucket. The map may contain only one of
-// these two possible keys.
+//   CID or [KV...]
+// i.e. it is represented as a "kinded union" where a Link is a pointer to a
+// child node, while an array is a bucket of elements local to this node. A
+// Pointer must represent exactly one of of these two states and cannot be both
+// (or neither).
 //
 // There are between 1 and 2^bitWidth of these Pointers in any HAMT node.
 //
@@ -93,20 +91,17 @@ type Node struct {
 // the bucket is replaced with a link to a newly created HAMT node which will
 // contain the `bucketSize+1` elements in its own Pointers array.
 //
-// (Note: the `refmt` tags are ignored by cbor-gen which will generate an
-// array type rather than map.)
-//
 // The IPLD Schema representation of this data structure is as follows:
 //
 // 		type Pointer union {
-//			&Node "0"
-// 			Bucket "1"
-// 		} representation keyed
+//			&Node link
+// 			Bucket list
+// 		} representation kinded
 //
 //		type Bucket [KV]
 type Pointer struct {
-	KVs  []*KV   `refmt:"v,omitempty"`
-	Link cid.Cid `refmt:"l,omitempty"`
+	KVs  []*KV
+	Link cid.Cid
 
 	// cached node to avoid too many serialization operations
 	// TODO(rvagg): we should check that this is actually used optimally. Flush()
@@ -373,6 +368,7 @@ func loadNode(
 		isLink := ch.isShard()
 		isBucket := ch.KVs != nil
 		if !((isLink && !isBucket) || (!isLink && isBucket)) {
+			// Pointer#UnmarshalCBOR shouldn't allow this
 			return nil, ErrMalformedHamt
 		}
 		if isLink && ch.Link.Type() != cid.DagCBOR { // not dag-cbor

--- a/pointer_cbor.go
+++ b/pointer_cbor.go
@@ -8,8 +8,8 @@ import (
 	cbg "github.com/whyrusleeping/cbor-gen"
 )
 
-var keyZero = []byte("0")
-var keyOne = []byte("1")
+// implemented as a kinded union - a "Pointer" is either a Link (child node) or
+// an Array (bucket)
 
 func (t *Pointer) MarshalCBOR(w io.Writer) error {
 	if t.Link != cid.Undef && len(t.KVs) > 0 {
@@ -18,36 +18,11 @@ func (t *Pointer) MarshalCBOR(w io.Writer) error {
 
 	scratch := make([]byte, 9)
 
-	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajMap, 1); err != nil {
-		return err
-	}
-
 	if t.Link != cid.Undef {
-		// key for links is "0"
-		// Refmt (and the general IPLD data model currently) can't deal
-		// with non string keys. So we have this weird restriction right now
-		// hoping to be able to use integer keys soon
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, 1); err != nil {
-			return err
-		}
-
-		if _, err := w.Write(keyZero); err != nil {
-			return err
-		}
-
 		if err := cbg.WriteCidBuf(scratch, w, t.Link); err != nil {
 			return err
 		}
 	} else {
-		// key for KVs is "1"
-		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, 1); err != nil {
-			return err
-		}
-
-		if _, err := w.Write(keyOne); err != nil {
-			return err
-		}
-
 		if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(t.KVs))); err != nil {
 			return err
 		}
@@ -69,51 +44,29 @@ func (t *Pointer) UnmarshalCBOR(br io.Reader) error {
 	if err != nil {
 		return err
 	}
-	if maj != cbg.MajMap {
-		return fmt.Errorf("cbor input should be of map")
-	}
 
-	if extra != 1 {
-		return fmt.Errorf("Pointers should be a single element map")
-	}
+	if maj == cbg.MajTag {
+		if extra != 42 {
+			return fmt.Errorf("expected tag 42 for child node link")
+		}
 
-	maj, val, err := cbg.CborReadHeaderBuf(br, scratch)
-	if err != nil {
-		return err
-	}
-
-	if maj != cbg.MajTextString {
-		return fmt.Errorf("expected text string key")
-	}
-
-	if val != 1 {
-		return fmt.Errorf("map keys in pointers must be a single byte long")
-	}
-
-	if _, err := io.ReadAtLeast(br, scratch[:1], 1); err != nil {
-		return err
-	}
-
-	switch scratch[0] {
-	case '0':
-		c, err := cbg.ReadCid(br)
+		ba, err := cbg.ReadByteArray(br, 512)
 		if err != nil {
 			return err
 		}
+
+		c, err := bufToCid(ba)
+		if err != nil {
+			return err
+		}
+
 		t.Link = c
 		return nil
-	case '1':
-		maj, length, err := cbg.CborReadHeaderBuf(br, scratch)
-		if err != nil {
-			return err
-		}
-
-		if maj != cbg.MajArray {
-			return fmt.Errorf("expected an array of KVs in cbor input")
-		}
+	} else if maj == cbg.MajArray {
+		length := extra
 
 		if length > 32 {
-			return fmt.Errorf("KV array in cbor input for pointer was too long")
+			return fmt.Errorf("KV array in CBOR input for pointer was too long")
 		}
 
 		t.KVs = make([]*KV, length)
@@ -127,7 +80,24 @@ func (t *Pointer) UnmarshalCBOR(br io.Reader) error {
 		}
 
 		return nil
-	default:
-		return fmt.Errorf("invalid pointer map key in cbor input: %d", val)
+	} else {
+		return fmt.Errorf("expected CBOR child node link or array")
 	}
+}
+
+// from https://github.com/whyrusleeping/cbor-gen/blob/211df3b9e24c6e0d0c338b440e6ab4ab298505b2/utils.go#L530
+func bufToCid(buf []byte) (cid.Cid, error) {
+	if len(buf) == 0 {
+		return cid.Undef, fmt.Errorf("undefined CID")
+	}
+
+	if len(buf) < 2 {
+		return cid.Undef, fmt.Errorf("DAG-CBOR serialized CIDs must have at least two bytes")
+	}
+
+	if buf[0] != 0 {
+		return cid.Undef, fmt.Errorf("DAG-CBOR serialized CIDs must have binary multibase")
+	}
+
+	return cid.Cast(buf[1:])
 }


### PR DESCRIPTION
From:

	type Pointer union {
		&Node "0"
		Bucket "1"
	} representation keyed

i.e. `{"0": CID}` or `{"1": [KV...]}`

To:

	type Pointer union {
		&Node link
		Bucket list
	} representation kinded

i.e. `CID` or `[KV...]`

Also removes redundant refmt tags.

Diff is hard to see because this bundles unmerged PRs #56 and #59. Only the last commit contains the main change here, currently that's 7597825.

Because TestMalformedHamt has some manually generated CBOR you can see the change in the block layout there and the simplification this introduces.

Closes: #53