### PR TITLE
Additional benchmarks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
 language: go
 
 go:
-  - 1.11.x
+  - 1.13.x
 
 env:
   global:

--- a/hamt.go
+++ b/hamt.go
@@ -358,10 +358,16 @@ func LoadNode(ctx context.Context, cs cbor.IpldStore, c cid.Cid, options ...Opti
 	return &out, nil
 }
 
-// Calculate the total _byte weight_ of the HAMT by fetching each node
-// from the IpldStore and adding its raw byte size to the total. This
-// operation will exhaustively load every node of the HAMT so should not
-// be used lightly.
+// checkSize computes the total serialized size of the entire HAMT.
+// It both puts and loads blocks as necesary to do this
+// (using the Put operation and a paired Get to discover the serial size,
+// and the load to move recursively as necessary).
+//
+// This is an expensive operation and should only be used in testing and analysis.
+//
+// Note that checkSize *does* actually *use the blockstore*: therefore it
+// will affect get and put counts (and makes no attempt to avoid duplicate puts!);
+// be aware of this if you are measuring those event counts.
 func (n *Node) checkSize(ctx context.Context) (uint64, error) {
 	c, err := n.store.Put(ctx, n)
 	if err != nil {

--- a/hamt_bench_test.go
+++ b/hamt_bench_test.go
@@ -60,8 +60,11 @@ var benchSetCaseTable []benchSetCase
 func init() {
 	kCounts := []int{
 		1,
+		5,
 		10,
+		50,
 		100,
+		500,
 		1000, // aka 1M
 		//10000, // aka 10M -- you'll need a lot of RAM for this.  Also, some patience.
 	}
@@ -80,6 +83,16 @@ func init() {
 		}
 	}
 }
+
+// The benchmark results can be graphed.  Here are some reasonable selections:
+/*
+	benchdraw --filter=BenchmarkFill          --plot=line --x=n "--y=blocks/entry"                 < sample > BenchmarkFill-blocks-per-entry-vs-scale.svg
+	benchdraw --filter=BenchmarkFill          --plot=line --x=n "--y=bytes(blockstoreAccnt)/entry" < sample > BenchmarkFill-totalBytes-per-entry-vs-scale.svg
+	benchdraw --filter=BenchmarkSetBulk       --plot=line --x=n "--y=addntlBlocks/addntlEntry"     < sample > BenchmarkSetBulk-addntlBlocks-per-addntlEntry-vs-scale.svg
+	benchdraw --filter=BenchmarkSetIndividual --plot=line --x=n "--y=addntlBlocks/addntlEntry"     < sample > BenchmarkSetIndividual-addntlBlocks-per-addntlEntry-vs-scale.svg
+	benchdraw --filter=BenchmarkFind          --plot=line --x=n "--y=ns/op"                        < sample > BenchmarkFind-speed-vs-scale.svg
+*/
+// (The 'benchdraw' command alluded to here is https://github.com/cep21/benchdraw .)
 
 // Histograms of blocksizes can be logged from some of the following functions, but are commented out.
 // The main thing to check for in those is whether there are any exceptionally small blocks being produced:

--- a/hamt_test.go
+++ b/hamt_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/rand"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -36,6 +37,66 @@ func (mb *mockBlocks) Get(c cid.Cid) (block.Block, error) {
 func (mb *mockBlocks) Put(b block.Block) error {
 	mb.data[b.Cid()] = b
 	return nil
+}
+
+func (mb *mockBlocks) totalBlockSizes() int {
+	sum := 0
+	for _, v := range mb.data {
+		sum += len(v.RawData())
+	}
+	return sum
+}
+
+type blockSizesHistogram [12]int
+
+func (mb *mockBlocks) getBlockSizesHistogram() (h blockSizesHistogram) {
+	for _, v := range mb.data {
+		l := len(v.RawData())
+		switch {
+		case l <= 2<<2: // 8
+			h[0]++
+		case l <= 2<<3: // 16
+			h[1]++
+		case l <= 2<<4: // 32
+			h[2]++
+		case l <= 2<<5: // 64
+			h[3]++
+		case l <= 2<<6: // 128
+			h[4]++
+		case l <= 2<<7: // 256
+			h[5]++
+		case l <= 2<<8: // 512
+			h[6]++
+		case l <= 2<<9: // 1024
+			h[7]++
+		case l <= 2<<10: // 2048
+			h[8]++
+		case l <= 2<<11: // 4096
+			h[9]++
+		case l <= 2<<12: // 8192
+			h[10]++
+		default:
+			h[11]++
+		}
+	}
+	return
+}
+
+func (h blockSizesHistogram) String() string {
+	v := "["
+	v += "<=" + strconv.Itoa(2<<2) + ":" + strconv.Itoa(h[0]) + ", "
+	v += "<=" + strconv.Itoa(2<<3) + ":" + strconv.Itoa(h[1]) + ", "
+	v += "<=" + strconv.Itoa(2<<4) + ":" + strconv.Itoa(h[2]) + ", "
+	v += "<=" + strconv.Itoa(2<<5) + ":" + strconv.Itoa(h[3]) + ", "
+	v += "<=" + strconv.Itoa(2<<6) + ":" + strconv.Itoa(h[4]) + ", "
+	v += "<=" + strconv.Itoa(2<<7) + ":" + strconv.Itoa(h[5]) + ", "
+	v += "<=" + strconv.Itoa(2<<8) + ":" + strconv.Itoa(h[6]) + ", "
+	v += "<=" + strconv.Itoa(2<<9) + ":" + strconv.Itoa(h[7]) + ", "
+	v += "<=" + strconv.Itoa(2<<10) + ":" + strconv.Itoa(h[8]) + ", "
+	v += "<=" + strconv.Itoa(2<<11) + ":" + strconv.Itoa(h[9]) + ", "
+	v += "<=" + strconv.Itoa(2<<12) + ":" + strconv.Itoa(h[10]) + ", "
+	v += ">" + strconv.Itoa(2<<12) + ":" + strconv.Itoa(h[11])
+	return v + "]"
 }
 
 func randString() string {


### PR DESCRIPTION
This PR contains a variety of new and extended benchmarks.

Existing benchmarks were moved to standardized benchmark names and standardized tables for parameters -- This is useful if we want to do charting (which will indeed be discussed later in the PR comment!  Just hang on).

Set vs Fill benchmarks are introduced.  Fill benchmarks (already existed, but renamed) measure how long it takes to create an entire hamt of some size; the Set benchmarks do an additional 1000 operations on top of an already created hamt, which offers more insight into costs of operations at particular scales.

Many new stats are tracked, using the now-standard ReportMetric feature:
- bytes per entry (both as counted as reachable by the hamt, and also as counted as present in the blockstore)
- blocks created per entry
- numbers of get and put events on the blockstore
- and more!
- Some histograms are also available, but are commented out, as I haven't yet found a pleasing way to present them.
- Some tests exist in both bulk flush and individual flush modes, which produce interestingly different statistics.

The `mockBlocks` type was extended to add accounting for many of these statistics.  (We can imagine using this in the future to make more tests asserting, for example, the number of get and put events expected for some operation.  That's left for future work, however.)

---

Now, for some selected results!

I charted these using https://github.com/cep21/benchdraw .  Instructions for reproducing these can be found in the comments in the diff body.

---

![BenchmarkFill-blocks-per-entry-vs-scale](https://user-images.githubusercontent.com/627638/90053421-c1c33b00-dcda-11ea-9328-302f64d0f3a6.png)

First of all: the number of blocks created in the blockstore per entry placed into a hamt during the Fill test: is... random?

The reason for this appears to be that creation of subshards during value insertion will unconditionally and immediately Put to the blockstore.  (This might be a bit surprising, since almost every other logical branch that value insertion and update can take will mutate cache nodes, and not immediately do a Put.)

This seems like it could represent a lot of unnecessary garbage block creation.  However, this may vary by workloads: if a workload can't bulk its writes anyway, this may simply not matter in practice.  (I don't have a lot of information about workloads right now.)

---

![BenchmarkFind-getEvts-vs-scale](https://user-images.githubusercontent.com/627638/90053715-28485900-dcdb-11ea-98a2-1eda7193e185.png)

Get events to perform a lookup: larger bitwidth parameters need fewer get events.  Larger hamts need slowly more gets, of course.  No big surprises here.  (I like no surprises.)

---

![BenchmarkSetIndividual-addntlBlocks-per-addntlEntry-vs-scale](https://user-images.githubusercontent.com/627638/90053851-54fc7080-dcdb-11ea-9526-ad7a09b599bf.png)

The number of addtional blocks created during inserting entries: is also higher for smaller bitwdiths.  Larger hamts also need slowly more blocks.  This is also simple good confirmatory news: it scales reasonably nicely.

---

More benchmarks could be useful in the future.  In particular I'm very aware that these are benchmarking synthetic operations; more information about actual workloads could result in much more interesting benchmarks.  But hopefully these are useful, and have useful outlines of how to do yet more in the future.