### PR TITLE
Introducing filecoin's go-hamt-ipld v2

### DIFF
--- a/gen/main.go
+++ b/gen/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	cbg "github.com/whyrusleeping/cbor-gen"
 
-	hamt "github.com/filecoin-project/go-hamt-ipld"
+	hamt "github.com/filecoin-project/go-hamt-ipld/v2"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/filecoin-project/go-hamt-ipld
+module github.com/filecoin-project/go-hamt-ipld/v2
 
 require (
 	github.com/ipfs/go-block-format v0.0.2


### PR DESCRIPTION
Closes #66 

Once this merges I will tag 2.0.0
Note that I tagged the pre-breakage hamt (before we validated bucket order on load) as 0.1.4.  0.1.1 is also tagged at this commit, but I wanted the latest tag to be the one people would actually use.  Changes from 0.1.2 and 0.1.3 should be pulled in through 2.x.x