### PR TITLE
SetIfAbsent

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,11 @@ require (
 	github.com/ipfs/go-block-format v0.0.2
 	github.com/ipfs/go-cid v0.0.6
 	github.com/ipfs/go-ipld-cbor v0.0.4
+	github.com/ipfs/go-ipld-format v0.0.2 // indirect
 	github.com/spaolacci/murmur3 v1.1.0
 	github.com/stretchr/testify v1.6.1
 	github.com/whyrusleeping/cbor-gen v0.0.0-20200806213330-63aa96ca5488
+	golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb // indirect
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
 )
 

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,7 @@ github.com/gxed/hashland/murmur3 v0.0.1/go.mod h1:KjXop02n4/ckmZSnY2+HKcLud/tcmv
 github.com/ipfs/go-block-format v0.0.2 h1:qPDvcP19izTjU8rgo6p7gTXZlkMkF5bz5G3fqIsSCPE=
 github.com/ipfs/go-block-format v0.0.2/go.mod h1:AWR46JfpcObNfg3ok2JHDUfdiHRgWhJgCQF+KIgOPJY=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
+github.com/ipfs/go-cid v0.0.2/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.3 h1:UIAh32wymBpStoe83YCzwVQQ5Oy/H0FdxvUS6DJDzms=
 github.com/ipfs/go-cid v0.0.3/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.6 h1:go0y+GcDOGeJIV01FeBsta4FHngoA4Wz7KMeLkXAhMs=
@@ -20,6 +21,8 @@ github.com/ipfs/go-ipld-cbor v0.0.4 h1:Aw3KPOKXjvrm6VjwJvFf1F1ekR/BH3jdof3Bk7OTi
 github.com/ipfs/go-ipld-cbor v0.0.4/go.mod h1:BkCduEx3XBCO6t2Sfo5BaHzuok7hbhdMm9Oh8B2Ftq4=
 github.com/ipfs/go-ipld-format v0.0.1 h1:HCu4eB/Gh+KD/Q0M8u888RFkorTWNIL3da4oc5dwc80=
 github.com/ipfs/go-ipld-format v0.0.1/go.mod h1:kyJtbkDALmFHv3QR6et67i35QzO3S0dCDnkOJhcZkms=
+github.com/ipfs/go-ipld-format v0.0.2 h1:OVAGlyYT6JPZ0pEfGntFPS40lfrDmaDbQwNHEY2G9Zs=
+github.com/ipfs/go-ipld-format v0.0.2/go.mod h1:4B6+FM2u9OJ9zCV+kSbgFAZlOrv1Hqbf0INGQgiKf9k=
 github.com/jtolds/gls v4.2.1+incompatible h1:fSuqC+Gmlu6l/ZYAoZzx2pyucC8Xza35fpRVWLVmUEE=
 github.com/jtolds/gls v4.2.1+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1 h1:lYpkrQH5ajf0OXOcUbGjvZxxijuBwbbmlSxLiuofa+g=
@@ -82,6 +85,8 @@ golang.org/x/sys v0.0.0-20190219092855-153ac476189d h1:Z0Ahzd7HltpJtjAHHxX8QFP3j
 golang.org/x/sys v0.0.0-20190219092855-153ac476189d/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb h1:fgwFCsaw9buMuxNd6+DQfAuSFqbNiQZpcgJQAgJsK6k=
+golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/hamt_test.go
+++ b/hamt_test.go
@@ -587,26 +587,21 @@ func TestSetIfAbsent(t *testing.T) {
 	val1 := []byte("owl bear")
 	key := "favorite-animal"
 	success, err := begn.SetIfAbsent(ctx, key, val1)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if !success {
 		t.Fatal("expected fresh set to work")
 	}
 
 	val2 := []byte("bright green bear")
 	success, err = begn.SetIfAbsent(ctx, key, val2)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if success {
 		t.Fatal("expected duplicate set to fail")
 	}
 
 	success, err = begn.SetIfAbsent(ctx, key, val1)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	if success {
 		t.Fatal("expected duplicate set with same value to also fail")
 	}
@@ -616,18 +611,12 @@ func TestSetIfAbsent(t *testing.T) {
 		t.Fatal(err)
 	}
 	c, err := cs.Put(ctx, begn)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	n, err := LoadNode(ctx, cs, c)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	success, err = n.SetIfAbsent(ctx, key, val2)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if success {
 		t.Fatal("expected duplicate set after flush to fail")
 	}
@@ -642,23 +631,14 @@ func TestSetWithNoEffectDoesNotPut(t *testing.T) {
 	// Fill up the root node so flushes actually Put to store
 	fillUpEntries := 2 * bucketSize * 5 // do 5 x the amount needed to fill up root node to fill with high probability
 	for i := 0; i < fillUpEntries; i++ {
-		if err := begn.Set(ctx, strconv.Itoa(i), []byte("filler")); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, begn.Set(ctx, strconv.Itoa(i), []byte("filler")))
 	}
-	if err := begn.Flush(ctx); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, begn.Flush(ctx))
 
 	key := "favorite-animal"
 	val1 := []byte("bright green bear")
-	err := begn.Set(ctx, key, val1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := begn.Flush(ctx); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, begn.Set(ctx, key, val1))
+	require.NoError(t, begn.Flush(ctx))
 
 	firstPutCount := mb.stats.evtcntPut
 	if firstPutCount <= 0 {
@@ -666,13 +646,9 @@ func TestSetWithNoEffectDoesNotPut(t *testing.T) {
 	}
 
 	// Set does not change key value mapping
-	err = begn.Set(ctx, key, val1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := begn.Flush(ctx); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, begn.Set(ctx, key, val1))
+	require.NoError(t, begn.Flush(ctx))
+
 	secondPutCount := mb.stats.evtcntPut
 	if secondPutCount != firstPutCount {
 		t.Fatalf("expected first Put count %d to equal second Put count %d", firstPutCount, secondPutCount)

--- a/hamt_test.go
+++ b/hamt_test.go
@@ -579,6 +579,106 @@ func testBasic(t *testing.T, options ...Option) {
 	}
 }
 
+func TestSetIfAbsent(t *testing.T) {
+	ctx := context.Background()
+	cs := cbor.NewCborStore(newMockBlocks())
+	begn := NewNode(cs)
+
+	val1 := []byte("owl bear")
+	key := "favorite-animal"
+	success, err := begn.SetIfAbsent(ctx, key, val1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !success {
+		t.Fatal("expected fresh set to work")
+	}
+
+	val2 := []byte("bright green bear")
+	success, err = begn.SetIfAbsent(ctx, key, val2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if success {
+		t.Fatal("expected duplicate set to fail")
+	}
+
+	success, err = begn.SetIfAbsent(ctx, key, val1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if success {
+		t.Fatal("expected duplicate set with same value to also fail")
+	}
+
+	// Behavior persists across flushes
+	if err := begn.Flush(ctx); err != nil {
+		t.Fatal(err)
+	}
+	c, err := cs.Put(ctx, begn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	n, err := LoadNode(ctx, cs, c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	success, err = n.SetIfAbsent(ctx, key, val2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if success {
+		t.Fatal("expected duplicate set after flush to fail")
+	}
+}
+
+func TestSetWithNoEffectDoesNotPut(t *testing.T) {
+	ctx := context.Background()
+	mb := newMockBlocks()
+	cs := cbor.NewCborStore(mb)
+	begn := NewNode(cs, UseTreeBitWidth(1)) // branching factor of 2 to fill up root node quickly
+
+	// Fill up the root node so flushes actually Put to store
+	fillUpEntries := 2 * bucketSize * 5 // do 5 x the amount needed to fill up root node to fill with high probability
+	for i := 0; i < fillUpEntries; i++ {
+		if err := begn.Set(ctx, strconv.Itoa(i), []byte("filler")); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := begn.Flush(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	key := "favorite-animal"
+	val1 := []byte("bright green bear")
+	err := begn.Set(ctx, key, val1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := begn.Flush(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	firstPutCount := mb.stats.evtcntPut
+	if firstPutCount <= 0 {
+		t.Fatal("expect first flush to Put to store")
+	}
+
+	// Set does not change key value mapping
+	err = begn.Set(ctx, key, val1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := begn.Flush(ctx); err != nil {
+		t.Fatal(err)
+	}
+	secondPutCount := mb.stats.evtcntPut
+	if secondPutCount != firstPutCount {
+		t.Fatalf("expected first Put count %d to equal second Put count %d", firstPutCount, secondPutCount)
+	}
+}
+
 func TestDelete(t *testing.T) {
 	ctx := context.Background()
 	cs := cbor.NewCborStore(newMockBlocks())


### PR DESCRIPTION
Closes #75 with the `SetIfAbsent` approach

* `modifyValue` now returns a boolean indicating whether or not it has changed the subtree
* `modifyValue` now takes in an overwrite boolean which only allows overwriting existing keys when true
* `SetIfAbsent` exported function

Tests still needed