### PR TITLE
Use CBOR-marshal interfaces for values

### DIFF
--- a/hamt_bench_test.go
+++ b/hamt_bench_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	cbor "github.com/ipfs/go-ipld-cbor"
+	cbg "github.com/whyrusleeping/cbor-gen"
 )
 
 type rander struct {
@@ -21,10 +22,10 @@ func (r *rander) randString() string {
 	return hex.EncodeToString(buf)
 }
 
-func (r *rander) randValue() []byte {
+func (r *rander) randValue() *cbg.Deferred {
 	buf := make([]byte, 30)
 	rand.Read(buf)
-	return buf
+	return &cbg.Deferred{Raw: buf}
 }
 
 func BenchmarkSerializeNode(b *testing.B) {

--- a/hamt_utils_test.go
+++ b/hamt_utils_test.go
@@ -1,5 +1,12 @@
 package hamt
 
+import (
+	"fmt"
+	"io"
+
+	cbg "github.com/whyrusleeping/cbor-gen"
+)
+
 // test utilities
 // from https://github.com/polydawn/refmt/blob/3d65705ee9f12dc0dfcc0dc6cf9666e97b93f339/cbor/cborFixtures_test.go#L81-L93
 
@@ -16,3 +23,36 @@ func bcat(bss ...[]byte) []byte {
 }
 
 func b(b byte) []byte { return []byte{b} }
+
+// A CBOR-marshalable byte array.
+type CborByteArray []byte
+
+func (c *CborByteArray) MarshalCBOR(w io.Writer) error {
+	if err := cbg.WriteMajorTypeHeader(w, cbg.MajByteString, uint64(len(*c))); err != nil {
+		return err
+	}
+	_, err := w.Write(*c)
+	return err
+}
+
+func (c *CborByteArray) UnmarshalCBOR(r io.Reader) error {
+	maj, extra, err := cbg.CborReadHeader(r)
+	if err != nil {
+		return err
+	}
+	if maj != cbg.MajByteString {
+		return fmt.Errorf("expected byte array")
+	}
+	if uint64(cap(*c)) < extra {
+		*c = make([]byte, extra)
+	}
+	if _, err := io.ReadFull(r, *c); err != nil {
+		return err
+	}
+	return nil
+}
+
+func cborstr(s string) *CborByteArray {
+	v := CborByteArray(s)
+	return &v
+}


### PR DESCRIPTION
Changes Get/Set value types to be `CBOR[Un]Marshaler` from whyrusleeping/cbor-gen, and removes fallback encoding via refmt. All the filecoin types define their CBOR encoding with cbor-gen.

I attempted to break the dependency on cbor-gen by repeating the interfaces here, but was stuck with the dependency due to use of `cbg.Deferred`. You'll see that I added a `CborByteArray` type for testing. Both `Deferred` and this array should probably be extracted to a filecoin CBOR utility repo. The tools for manually working with CBOR are frustratingly incomplete.

I also attempted to break the dep on `go-ipld-cbor`, but rolled back because we still need the `BasicIpldStore`. That store does things we don't want (also has refmt fallback), and might be an easier dependency to break via a local utility repo.

Closes #78.