### PR TITLE
NewNode returns error on invalid configuration

### DIFF
--- a/hash.go
+++ b/hash.go
@@ -64,6 +64,9 @@ func (hb *hashBits) next(i int) int {
 
 func defaultHashFunction(val []byte) []byte {
 	h := murmur3.New64()
-	h.Write(val)
+	_, err := h.Write(val)
+	if err != nil {
+		panic(err) // Impossible
+	}
 	return h.Sum(nil)
 }

--- a/options.go
+++ b/options.go
@@ -1,0 +1,60 @@
+package hamt
+
+import "fmt"
+
+const bucketSize = 3
+const defaultBitWidth = 8
+
+type config struct {
+	bitWidth int
+	hashFn   HashFunc
+}
+
+func defaultConfig() *config {
+	return &config{
+		bitWidth: defaultBitWidth,
+		hashFn:   defaultHashFunction,
+	}
+}
+
+// Option is a function that configures a HAMT.
+type Option func(*config) error
+
+// UseTreeBitWidth allows you to set a custom bitWidth of the HAMT in bits
+// (from 1-8).
+//
+// Passing in the returned Option to NewNode will generate a new HAMT that uses
+// the specified bitWidth.
+//
+// The default bitWidth is 8.
+func UseTreeBitWidth(bitWidth int) Option {
+	return func(c *config) error {
+		if bitWidth < 1 {
+			return fmt.Errorf("configured bitwidth %d below minimum of 1", bitWidth)
+		} else if bitWidth > 8 {
+			return fmt.Errorf("configured bitwidth %d exceeds maximum of 8", bitWidth)
+		}
+		c.bitWidth = bitWidth
+		return nil
+	}
+}
+
+// UseHashFunction allows you to set the hash function used for internal
+// indexing by the HAMT.
+//
+// Passing in the returned Option to NewNode will generate a new HAMT that uses
+// the specified hash function.
+//
+// The default hash function is murmur3-x64 but you should use a
+// cryptographically secure function such as SHA2-256 if an attacker may be
+// able to pick the keys in order to avoid potential hash collision (tree
+// explosion) attacks.
+func UseHashFunction(hash HashFunc) Option {
+	return func(c *config) error {
+		if hash == nil {
+			return fmt.Errorf("configured hash function was nil")
+		}
+		c.hashFn = hash
+		return nil
+	}
+}


### PR DESCRIPTION
Changed HAMT node options and construction to follow a similar pattern to the AMT. The externally visible change is to return an error from the `Option` functions and `NewNode` if an invalid option is provided. Internally this prompted a little rework of inner node construction to avoid plumbing the same error through internal paths.

The AMT remains somewhat structurally superior in distinguishing the root node from others (see #79) and separate structures for the serialized type vs the inflated values.

I de-noised some error handling in tests, since I was adding new errors to be handled.

Closes #80