### PR TITLE
Replace ErrNotFound with boolean return value

### DIFF
--- a/hamt_bench_test.go
+++ b/hamt_bench_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	cbor "github.com/ipfs/go-ipld-cbor"
+	"github.com/stretchr/testify/require"
 	cbg "github.com/whyrusleeping/cbor-gen"
 )
 
@@ -261,9 +262,9 @@ func doBenchmarkEntriesCount(num int, bitWidth int) func(b *testing.B) {
 				b.Fatal(err)
 			}
 
-			if err = nd.Find(context.TODO(), keys[i%num], nil); err != nil {
-				b.Fatal(err)
-			}
+			found, err := nd.Find(context.TODO(), keys[i%num], nil)
+			require.NoError(b, err)
+			require.True(b, found, "key not found")
 		}
 		b.ReportMetric(float64(blockstore.stats.evtcntGet)/float64(b.N), "getEvts/find")
 		b.ReportMetric(float64(blockstore.stats.evtcntPut)/float64(b.N), "putEvts/find") // surely this is zero, but for completeness.


### PR DESCRIPTION
Removes ErrNotFound and replaces its use with an additional boolean return value from Find, FindRaw and Delete.

Depending on your view of whether ErrNotFound is a true error, this changes the semantics of Delete to make it not an "error" to attempt to delete a missing key.

Closes #82.