### PR TITLE
node.Write(ctx) method

### DIFF
--- a/hamt.go
+++ b/hamt.go
@@ -457,7 +457,22 @@ func (n *Node) checkSize(ctx context.Context) (uint64, error) {
 	return totsize, nil
 }
 
-// Flush has two effectis, it (partially!) persists data and resets dirty flag
+// Write is a convenience method that calls flush and writes the node to it's
+// internal store, returning the CID of the stored node. It is equivelant to:
+//   n.Flush
+//   store.Put(ctx, n)
+// where store is equal to the store provided to the node when constructed.
+//
+// write should only be called on the root node of a HAMT
+func (n *Node) Write(ctx context.Context) (cid.Cid, error) {
+	if err := n.Flush(ctx); err != nil {
+		return cid.Undef, err
+	}
+
+	return n.store.Put(ctx, n)
+}
+
+// Flush has two effects, it (partially!) persists data and resets dirty flag
 //
 // Flush operates recursively, telling each "cache" child node to flush;
 // Put'ing that "cache" node to the store;

--- a/hamt_test.go
+++ b/hamt_test.go
@@ -213,7 +213,7 @@ func TestFillAndCollapse(t *testing.T) {
 		t.Fatal("Should be 1 node with 1 bucket")
 	}
 
-	baseCid, err := cs.Put(ctx, root)
+	baseCid, err := root.Write(ctx)
 	require.NoError(t, err)
 
 	// add a 4th colliding entry that forces a chain of new nodes to accommodate
@@ -240,7 +240,7 @@ func TestFillAndCollapse(t *testing.T) {
 		t.Fatal("Should be 1 node with 1 bucket")
 	}
 
-	c, err := cs.Put(ctx, root)
+	c, err := root.Write(ctx)
 	require.NoError(t, err)
 
 	if !c.Equals(baseCid) {
@@ -263,7 +263,7 @@ func TestFillAndCollapse(t *testing.T) {
 		t.Fatal("Should be 4 nodes with 2 buckets of 3")
 	}
 
-	midCid, err := cs.Put(ctx, root)
+	midCid, err := root.Write(ctx)
 	require.NoError(t, err)
 
 	// insert an overflow node that pushes the previous 4 into a separate node
@@ -312,7 +312,7 @@ func TestFillAndCollapse(t *testing.T) {
 		t.Fatal("Should be 4 nodes with 2 buckets of 3")
 	}
 
-	c, err = cs.Put(ctx, root)
+	c, err = root.Write(ctx)
 	require.NoError(t, err)
 
 	if !c.Equals(midCid) {
@@ -338,7 +338,7 @@ func TestFillAndCollapse(t *testing.T) {
 	}
 
 	// should have the same CID as original
-	c, err = cs.Put(ctx, root)
+	c, err = root.Write(ctx)
 	require.NoError(t, err)
 	if !c.Equals(baseCid) {
 		t.Fatal("CID mismatch on mutation")
@@ -1281,7 +1281,7 @@ func TestPutOrderIndependent(t *testing.T) {
 
 	// Shouldn't matter but repeating original case exactly
 	require.NoError(t, h.Flush(ctx))
-	c, err := cs.Put(ctx, h)
+	c, err := h.Write(ctx)
 	require.NoError(t, err)
 
 	vals := make([]int, 100)
@@ -1305,7 +1305,7 @@ func TestPutOrderIndependent(t *testing.T) {
 		}
 
 		require.NoError(t, h.Flush(ctx))
-		c, err := cs.Put(ctx, h)
+		c, err := h.Write(ctx)
 		require.NoError(t, err)
 		res[c] = struct{}{}
 	}
@@ -1343,7 +1343,7 @@ func TestDeleteOrderIndependent(t *testing.T) {
 
 	// Shouldn't matter but repeating original case exactly
 	require.NoError(t, h.Flush(ctx))
-	c, err := cs.Put(ctx, h)
+	c, err := h.Write(ctx)
 	require.NoError(t, err)
 
 	vals := make([]int, 100)
@@ -1365,7 +1365,7 @@ func TestDeleteOrderIndependent(t *testing.T) {
 		}
 
 		require.NoError(t, h.Flush(ctx))
-		c, err := cs.Put(ctx, h)
+		c, err := h.Write(ctx)
 		require.NoError(t, err)
 		res[c] = struct{}{}
 	}


### PR DESCRIPTION
when attempting to use this library, it took a while to wrap my head around the API for writing a root. Adding this alias for the common Flush + n.store.Put pattern should help others see the way HAMT's are intended to be written. I've documented it as an alias to make it clear that the function can be broken out when flushing with a separate cadence than writing.

Call sites like https://github.com/filecoin-project/specs-actors/blob/0bcea9e3fa074b875135563cdaba6e786428c669/actors/util/adt/map.go#L71-L84

_could_ be replaced with `m.root.Write(m.Context()` if you're ok with a unified error on both flush & write failure, but again `Write` is an alias.

While auditing use of this codebase I could find no situation where the root node should / would be stored with a different store than the one provided to the HAMT at construction, leading me to believe this change may avoid misuse in userland.

Switched a few calls within tests where appropriate to use write instead of `cs.Put(ctx, root)` to both get the suite to work the method and show the change.