### PR TITLE
use of SetRaw constructs malformed HAMT

### DIFF
--- a/hamt.go
+++ b/hamt.go
@@ -201,19 +201,6 @@ func (n *Node) Find(ctx context.Context, k string, out cbg.CBORUnmarshaler) (boo
 	return found, err
 }
 
-// FindRaw performs the same function as Find, but returns the raw bytes found
-// at the key's location (which may or may not be DAG-CBOR, see also SetRaw).
-func (n *Node) FindRaw(ctx context.Context, k string) (bool, []byte, error) {
-	var found bool
-	var value []byte
-	err := n.getValue(ctx, &hashBits{b: n.hash([]byte(k))}, k, func(kv *KV) error {
-		found = true
-		value = kv.Value.Raw
-		return nil
-	})
-	return found, value, err
-}
-
 // Delete removes an entry from the HAMT structure.
 //
 // Returns true if the key was found and deleted, false if the key was absent.
@@ -534,16 +521,6 @@ func (n *Node) SetIfAbsent(ctx context.Context, k string, v cbg.CBORMarshaler) (
 	keyBytes := []byte(k)
 	modified, err := n.modifyValue(ctx, &hashBits{b: n.hash(keyBytes)}, keyBytes, &d, NOVERWRITE)
 	return bool(modified), err
-}
-
-// SetRaw is similar to Set but sets key k in the HAMT to raw bytes without
-// performing a DAG-CBOR marshal. The bytes may or may not be encoded DAG-CBOR
-// (see also FindRaw for fetching raw form).
-func (n *Node) SetRaw(ctx context.Context, k string, raw []byte) error {
-	d := &cbg.Deferred{Raw: raw}
-	kb := []byte(k)
-	_, err := n.modifyValue(ctx, &hashBits{b: n.hash(kb)}, kb, d, OVERWRITE)
-	return err
 }
 
 // the number of links to child nodes this node contains

--- a/hamt_test.go
+++ b/hamt_test.go
@@ -913,6 +913,34 @@ func TestSetNilValues(t *testing.T) {
 	}
 }
 
+func TestPutRaw(t *testing.T) {
+	ctx := context.Background()
+	blocks := newMockBlocks()
+	cs := cbor.NewCborStore(blocks)
+	n, err := NewNode(cs)
+	require.NoError(t, err)
+
+	expect := []byte("value")
+	err = n.SetRaw(ctx, "key", expect)
+	require.NoError(t, err)
+
+	_, got, err := n.FindRaw(ctx, "key")
+	require.NoError(t, err)
+	require.Equal(t, expect, got)
+
+	err = n.Flush(ctx)
+	require.NoError(t, err)
+	id, err := cs.Put(ctx, n)
+	require.NoError(t, err)
+
+	n, err = LoadNode(ctx, cs, id)
+	require.NoError(t, err)
+
+	_, got, err = n.FindRaw(ctx, "key")
+	require.NoError(t, err)
+	require.Equal(t, expect, got)
+}
+
 // Some tests that use manually constructed (and very basic) CBOR forms of
 // nodes to test whether the implementation will reject malformed encoded nodes
 // on load.

--- a/hamt_test.go
+++ b/hamt_test.go
@@ -913,34 +913,6 @@ func TestSetNilValues(t *testing.T) {
 	}
 }
 
-func TestPutRaw(t *testing.T) {
-	ctx := context.Background()
-	blocks := newMockBlocks()
-	cs := cbor.NewCborStore(blocks)
-	n, err := NewNode(cs)
-	require.NoError(t, err)
-
-	expect := []byte("value")
-	err = n.SetRaw(ctx, "key", expect)
-	require.NoError(t, err)
-
-	_, got, err := n.FindRaw(ctx, "key")
-	require.NoError(t, err)
-	require.Equal(t, expect, got)
-
-	err = n.Flush(ctx)
-	require.NoError(t, err)
-	id, err := cs.Put(ctx, n)
-	require.NoError(t, err)
-
-	n, err = LoadNode(ctx, cs, id)
-	require.NoError(t, err)
-
-	_, got, err = n.FindRaw(ctx, "key")
-	require.NoError(t, err)
-	require.Equal(t, expect, got)
-}
-
 // Some tests that use manually constructed (and very basic) CBOR forms of
 // nodes to test whether the implementation will reject malformed encoded nodes
 // on load.


### PR DESCRIPTION
This is mainly to get a discussion going with a failing test. Seems the Set/FindRaw methods aren't tested and don't seem to be working as expected.

running this test fails with:

```
$ go test --run TestPutRaw
--- FAIL: TestPutRaw (0.00s)
    hamt_test.go:937:
        	Error Trace:	hamt_test.go:937
        	Error:      	Received unexpected error:
        	            	failed to read deferred field: unexpected EOF
        	Test:       	TestPutRaw
FAIL
exit status 1
FAIL	github.com/filecoin-project/go-hamt-ipld/v3	0.149s
```

I don't have the bandwidth to find the proper fix, but could update this PR to _remove_ the `Raw` methods if that helps. The way I've been working around it is to have all values written to the HAMT implement the `CBOR` marshaling interface