### PR TITLE
Use cbor-gen readers and writers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,11 @@ require (
 	github.com/ipfs/go-ipld-cbor v0.0.4
 	github.com/spaolacci/murmur3 v1.1.0
 	github.com/stretchr/testify v1.7.0
-	github.com/whyrusleeping/cbor-gen v0.0.0-20200806213330-63aa96ca5488
+	github.com/whyrusleeping/cbor-gen v0.0.0-20220323183124-98fa8256a799
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 )
 
 require (
@@ -27,8 +29,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/polydawn/refmt v0.0.0-20190221155625-df39d6c2d992 // indirect
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // indirect
-	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
-	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -65,8 +65,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/warpfork/go-wish v0.0.0-20180510122957-5ad1f5abf436 h1:qOpVTI+BrstcjTZLm2Yz/3sOnqkzj3FQoh0g+E5s3Gc=
 github.com/warpfork/go-wish v0.0.0-20180510122957-5ad1f5abf436/go.mod h1:x6AKhvSSexNrVSrViXSHUEbICjmGXhtgABaHIySUSGw=
 github.com/whyrusleeping/cbor-gen v0.0.0-20200123233031-1cdf64d27158/go.mod h1:Xj/M2wWU+QdTdRbu/L/1dIZY8/Wb2K9pAhtroQuxJJI=
-github.com/whyrusleeping/cbor-gen v0.0.0-20200806213330-63aa96ca5488 h1:P/Q9QT99FpyHtFke7ERUqX7yYtZ/KigO880L+TKFyTQ=
-github.com/whyrusleeping/cbor-gen v0.0.0-20200806213330-63aa96ca5488/go.mod h1:fgkXqYy7bV2cFeIEOkVTZS/WjXARfBqSH6Q2qHL33hQ=
+github.com/whyrusleeping/cbor-gen v0.0.0-20220323183124-98fa8256a799 h1:DOOT2B85S0tHoLGTzV+FakaSSihgRCVwZkjqKQP5L/w=
+github.com/whyrusleeping/cbor-gen v0.0.0-20220323183124-98fa8256a799/go.mod h1:fgkXqYy7bV2cFeIEOkVTZS/WjXARfBqSH6Q2qHL33hQ=
 golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=


### PR DESCRIPTION
Benchmark comparison taken from https://github.com/whyrusleeping/cbor-gen/pull/67#issuecomment-1076547989 

```
name                       old time/op       new time/op       delta
SerializeNode-8                 9.88µs ±13%      10.92µs ± 5%  +10.54%  (p=0.009 n=10+10)
GetNode-8                       17.8µs ± 2%       14.4µs ± 5%  -19.13%  (p=0.000 n=10+10)
Find/n=1k/bitwidth=5-8          24.0µs ± 2%       23.0µs ± 2%   -3.98%  (p=0.000 n=10+10)
Find/n=5k/bitwidth=5-8          28.3µs ± 3%       27.7µs ± 5%     ~     (p=0.065 n=9+10)
Find/n=10k/bitwidth=5-8         23.1µs ± 3%       21.7µs ± 2%   -6.07%  (p=0.000 n=10+10)
Find/n=50k/bitwidth=5-8         38.4µs ± 7%       36.1µs ± 6%   -5.83%  (p=0.015 n=10+10)
Find/n=100k/bitwidth=5-8        41.0µs ± 8%       41.2µs ± 6%     ~     (p=1.000 n=10+10)
Find/n=500k/bitwidth=5-8        30.2µs ± 3%       29.3µs ± 4%   -3.29%  (p=0.003 n=10+10)
Find/n=1000k/bitwidth=5-8       36.7µs ± 2%       35.3µs ± 1%   -3.91%  (p=0.000 n=9+8)

name                       old alloc/op      new alloc/op      delta
SerializeNode-8                 14.9kB ± 3%       16.3kB ± 3%   +9.57%  (p=0.000 n=10+10)
GetNode-8                       20.7kB ± 0%       18.7kB ± 0%   -9.61%  (p=0.000 n=10+10)
Find/n=1k/bitwidth=5-8          35.0kB ± 2%       34.7kB ± 1%     ~     (p=0.156 n=10+9)
Find/n=5k/bitwidth=5-8          35.6kB ± 4%       35.4kB ± 6%     ~     (p=0.631 n=10+10)
Find/n=10k/bitwidth=5-8         23.3kB ± 2%       22.5kB ± 2%   -3.20%  (p=0.000 n=10+10)
Find/n=50k/bitwidth=5-8         51.2kB ± 0%       50.3kB ± 1%   -1.73%  (p=0.000 n=10+10)
Find/n=100k/bitwidth=5-8        55.0kB ± 1%       54.1kB ± 1%   -1.69%  (p=0.000 n=10+10)
Find/n=500k/bitwidth=5-8        33.5kB ± 0%       32.7kB ± 0%   -2.33%  (p=0.000 n=10+10)
Find/n=1000k/bitwidth=5-8       46.3kB ± 0%       45.3kB ± 0%   -2.06%  (p=0.000 n=10+10)

name                       old allocs/op     new allocs/op     delta
SerializeNode-8                    111 ± 2%          107 ± 5%   -3.86%  (p=0.001 n=10+10)
GetNode-8                          519 ± 0%          264 ± 0%  -49.13%  (p=0.000 n=10+10)
Find/n=1k/bitwidth=5-8             478 ± 2%          398 ± 1%  -16.63%  (p=0.000 n=10+10)
Find/n=10k/bitwidth=5-8            413 ± 1%          330 ± 1%  -20.25%  (p=0.000 n=10+10)
Find/n=50k/bitwidth=5-8            728 ± 0%          600 ± 0%  -17.50%  (p=0.000 n=10+9)
Find/n=100k/bitwidth=5-8           784 ± 0%          647 ± 0%  -17.45%  (p=0.000 n=10+10)
Find/n=500k/bitwidth=5-8           600 ± 0%          479 ± 0%  -20.17%  (p=0.000 n=10+10)
Find/n=1000k/bitwidth=5-8          743 ± 0%          602 ± 0%  -19.04%  (p=0.000 n=9+10)
```