### PR TITLE
fix: skip traversal of pointers with the same cid

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -80,6 +80,9 @@ func diffNode(ctx context.Context, pre, cur *Node, depth int) ([]*Change, error)
 
 			// both pointers are shards, recurse down the tree.
 			if prePointer.isShard() && curPointer.isShard() {
+				if prePointer.Link == curPointer.Link {
+					continue
+				}
 				preChild, err := prePointer.loadChild(ctx, pre.store, pre.bitWidth, pre.hash)
 				if err != nil {
 					return nil, err

--- a/diff_parallel.go
+++ b/diff_parallel.go
@@ -192,6 +192,9 @@ func (s *diffScheduler) work(ctx context.Context, todo *task, results chan *Chan
 		switch {
 		// both pointers are shards, recurse down the tree.
 		case prePointer.isShard() && curPointer.isShard():
+			if prePointer.Link == curPointer.Link {
+				return nil
+			}
 			preChild, err := prePointer.loadChild(ctx, pre.store, pre.bitWidth, pre.hash)
 			if err != nil {
 				return err


### PR DESCRIPTION
Tested with HAMTs with 1M keys and 1k changes.
Reduced test run time from 15.81s to 4.92s.